### PR TITLE
Fixes compilation errors and implements general improvements

### DIFF
--- a/mainbuild.mk
+++ b/mainbuild.mk
@@ -2,7 +2,7 @@ SRC=$(wildcard *.c)
 EXE=$(subst .c,,$(SRC))
 
 $(EXE): $(SRC)
-	gcc -Wall -Wextra -std=c99 -g -o $@ $^
+	gcc -Wall -Wextra -std=c99 -g -o $@.o $^
 
 test: tests
 

--- a/pointers/pointers.c
+++ b/pointers/pointers.c
@@ -47,8 +47,8 @@ char *find_string(char *haystack, char *needle)
 #ifndef TESTING
 int main(void)
 {
-    char *found_char = find_char(hello, 'e');
-    char *found_string = find_string(world, "or");
+    char *found_char = find_char("hello", 'e');
+    char *found_string = find_string("world", "or");
 
     printf("Found char: %s\n", found_char);
     printf("Found string: %s\n", found_string);

--- a/pointers/pointers.h
+++ b/pointers/pointers.h
@@ -1,13 +1,7 @@
 #ifndef pointers_h
 #define pointers_h
 
-void swap(int *a, int *b);
-
-int string_length(char *s);
-
 void string_copy(char *a, char *b);
-
-int string_compare(char *m, char *n);
 
 char *find_char(char *str, int c);
 

--- a/pointers/tests/pointers_tests.c
+++ b/pointers/tests/pointers_tests.c
@@ -54,6 +54,7 @@ char *all_tests()
 {
     mu_suite_start();
 
+    mu_run_test(test_string_copy);
     mu_run_test(test_find_char);
     mu_run_test(test_find_string);
 

--- a/queue/lib.h
+++ b/queue/lib.h
@@ -3,7 +3,7 @@
 
 #include <stdlib.h>
 
-void *resize_memory(void *ptr, int old_size, int new_size)
+void *resize_memory(void *ptr, int new_size)
 {
   return realloc(ptr, new_size);
 }

--- a/quicksort/quicksort.c
+++ b/quicksort/quicksort.c
@@ -2,9 +2,9 @@
 #include "lib.h" 
 
 /*
-    Implement the Quicksort algorithm. You'll likely want to re-use the
-    `swap` function you implemented in the pointers module (which is
-    already being included for you in this file).
+    Implement the Quicksort algorithm. You'll likely want to use the
+    `swap` function, which is
+    already being included for you in this file.
 
     The `low` and `high` parameters indicate the lowest and highest indices
     of the array that is getting passed in. This is necessary because the 

--- a/structs/lib.h
+++ b/structs/lib.h
@@ -3,6 +3,8 @@
 
 #include <string.h>
 
+char *strdup(const char *);
+
 char *string_dup(char *src)
 {
   return strdup(src);


### PR DESCRIPTION
The listed problems below are in order with the commits that fix them. 
Note that these problems occurred on [WSL](https://docs.microsoft.com/en-us/windows/wsl/about) and that these fixes were only tested on the same system.
- In [pointers/pointers.c](https://github.com/LambdaSchool/Intro-to-C/blob/master/pointers/pointers.c#L50), some of the strings in the main function are missing quotes, causing a compilation error out of the box.
- In [mainbuild.mk](https://github.com/LambdaSchool/Intro-to-C/blob/master/mainbuild.mk#L5), object files are being compiled with no extension. Assuming this isn't somehow system-dependent, then this change should happen so that these files aren't put in version control (when they are, it creates bloat for PMs and slows down pushes for the students).
- In [structs/lib.h](https://github.com/LambdaSchool/Intro-to-C/blob/master/structs/lib.h#L8), `strdup`'s function header is being assumed wrong due to the `-std=c99` flag used in the [mainbuild.mk](https://github.com/LambdaSchool/Intro-to-C/blob/master/mainbuild.mk#L5) file. This causes a runtime error, which doesn't allow students to successfully run their object code even with correct implementations. The problem is more thoroughly explained [here](https://stackoverflow.com/a/26284172/11186034).
- In [queue/lib.h](https://github.com/LambdaSchool/Intro-to-C/blob/master/queue/lib.h), an unnecessary, unused parameter is in `resize_memory`. It seems to only be confusing to abstract something away with misleading parameters.
- In [quicksort/quicksort.c](https://github.com/LambdaSchool/Intro-to-C/blob/master/quicksort/quicksort.c#L5), a `swap` function that has already been implemented is mentioned, but there is not a `swap` function to implement in the [pointers module](https://github.com/LambdaSchool/Intro-to-C/blob/master/pointers/pointers.c) currently.

The next commit is simply for merging the updates to the README into this branch.

- In [pointers/pointers.h](https://github.com/LambdaSchool/Intro-to-C/blob/master/pointers/pointers.h), there are a few unused function declarations. This could be potentially misleading/confusing.
- In [pointers/tests/pointers_tests.c](https://github.com/LambdaSchool/Intro-to-C/blob/master/pointers/tests/pointers_tests.c), the string copy test is never run. I assume this was just missed/forgotten about.